### PR TITLE
Add option to install Ruby version of htpasswd script

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default[:htpasswd][:install_dir] = "/usr/local/bin"
+default[:htpasswd][:script_lang] = 'python'

--- a/recipes/build-in.rb
+++ b/recipes/build-in.rb
@@ -18,9 +18,23 @@
 # limitations under the License.
 #
 
-cookbook_file "#{node[:htpasswd][:install_dir]}/htpasswd" do
-  source "htpasswd.py"
-  mode "0755"
-  owner "root"
-  group "root"
+case node[:htpasswd][:script_lang]
+when 'ruby'
+  package 'ruby'
+  gem_package 'htauth'
+  ruby_exec = `which ruby`.chomp
+  gem_bindir = `"#{ruby_exec}" -rrubygems -e 'puts Gem.bindir'`.chomp
+  link "#{gem_bindir}/htpasswd" do
+    to "#{gem_bindir}/htpasswd-ruby"
+    not_if "which htpasswd"
+  end
+when 'python'
+  cookbook_file "#{node[:htpasswd][:install_dir]}/htpasswd" do
+    source "htpasswd.py"
+    mode "0755"
+    owner "root"
+    group "root"
+  end
+else
+  raise "Unsupported htpasswd script version: #{node[:htpasswd][:script_lang]}"
 end


### PR DESCRIPTION
Got a request on the chef-kibana project for people to be able to use a ruby-only version of htpasswd (so as to avoid having to depend on Python, for what that's worth).  This PR should fulfill that request without affecting existing users.
