### PR TITLE
Add compile time false switch per https://blog.chef.io/2015/02/17/che…

### DIFF
--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -1,3 +1,4 @@
 chef_gem 'htauth' do
+  compile_time false if Chef::Resource::ChefGem.method_defined?(:compile_time)
   version '~> 1.1.0'
 end


### PR DESCRIPTION
Id like to add change to _common.rb to get rid of deprecation warnings when running chef-client

IE:

Running handlers:
Running handlers complete

Deprecated features used!
  chef_gem[htauth] chef_gem compile_time installation is deprecated at 1 location:
    - /var/chef/cache/cookbooks/htpasswd/recipes/_common.rb:1:in `from_file'
  chef_gem[htauth] Please set `compile_time false` on the resource to use the new behavior. at 1 location:
    - /var/chef/cache/cookbooks/htpasswd/recipes/_common.rb:1:in `from_file'
  chef_gem[htauth] or set `compile_time true` on the resource if compile_time behavior is required. at 1 location:
    - /var/chef/cache/cookbooks/htpasswd/recipes/_common.rb:1:in `from_file'

Details can be read here: https://blog.chef.io/2015/02/17/chef-12-1-0-chef_gem-resource-warnings/