### PR TITLE
Lock htauth gem version to 2.0.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -22,4 +22,4 @@ source_url 'https://github.com/redguide/htpasswd' if respond_to?(:source_url)
 issues_url 'https://github.com/redguide/htpasswd/issues' if respond_to?(:issues_url)
 chef_version '>= 12.8' if respond_to?(:chef_version)
 
-gem 'htauth' if respond_to?(:gem)
+gem 'htauth', '= 2.0.0' if respond_to?(:gem)


### PR DESCRIPTION
htauth was upgraded April 2nd 2020 to version 2.1.1 and now requires bcrypt that needs to be compiled at runtime. Currently this breaks the cookbook for environments where this is not possible.

This is a workaround to make sure that we keep using the same version of htauth that has been used for a long time now.

