### PR TITLE
fix helper script to use file instead of name property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the htpasswd cookbook.
 
 ## Unreleased
 
-- fix helper script to use file instead of name property
+- Fix helper script to use file instead of name property
 
 ## 2.0.2 - *2021-06-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the htpasswd cookbook.
 
 ## Unreleased
 
+- fix helper script to use file instead of name property
+
 ## 2.0.2 - *2021-06-08*
 
 - [CI] Update ActionsHub actions to point at main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This file is used to list changes made in each version of the htpasswd cookbook.
 
 ## 2.0.1 - *2021-06-01*
 
+- Standardise files with files in sous-chefs/repo-management
+
 ## 2.0.0 - *2021-05-13*
 
 - Chef 17 updates: enable `unified_mode` on all resources

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -4,7 +4,7 @@ module Htpasswd
       private
 
       def fix_perms(new_resource)
-        file new_resource.name do
+        file new_resource.file do
           # owner new_resource.owner
           # group new_resource.group
           mode new_resource.mode


### PR DESCRIPTION
# Description

fixes bug where helper script changes file permissions on name property instead of file property

## Issues Resolved

List any existing issues this PR resolves
https://github.com/sous-chefs/htpasswd/issues/45


## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
