### PR TITLE
Update GitHub Actions branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,18 @@ name: ci
 "on":
   pull_request:
   push:
-    branches:
-      - master
+    branches: [master, main]
 
 jobs:
   delivery:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@master
+        uses: actionshub/chef-delivery@main
         with:
-          gems: 'htauth'
+          gems: "htauth"
         env:
           CHEF_LICENSE: accept-no-persist
 
@@ -24,17 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Run yaml Lint
-        uses: actionshub/yamllint@master
+        uses: actionshub/yamllint@main
 
   mdl:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Run Markdown Lint
-        uses: actionshub/markdownlint@master
+        uses: actionshub/markdownlint@main
 
   dokken:
     needs: [mdl, yamllint, delivery]
@@ -42,23 +41,23 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'debian-9'
-          - 'debian-10'
-          - 'centos-7'
-          - 'centos-8'
-          - 'ubuntu-1804'
-          - 'ubuntu-2004'
+          - "debian-9"
+          - "debian-10"
+          - "centos-7"
+          - "centos-8"
+          - "ubuntu-1804"
+          - "ubuntu-2004"
         suite:
-          - 'default'
+          - "default"
       fail-fast: false
 
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Install Chef
-        uses: actionshub/chef-install@master
+        uses: actionshub/chef-install@main
       - name: Dokken
-        uses: actionshub/kitchen-dokken@master
+        uses: actionshub/kitchen-dokken@main
         env:
           CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
@@ -71,4 +70,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2

--- a/.github/workflows/md-links.yml
+++ b/.github/workflows/md-links.yml
@@ -4,14 +4,14 @@ name: md-links
 "on":
   pull_request:
   push:
-    branches: [master]
+    branches: [master, main]
 
 jobs:
   md-links:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@main
+        uses: actions/checkout@v2
       - name: markdown-link-check
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the htpasswd cookbook.
 
 ## Unreleased
 
+- [CI] Update ActionsHub actions to point at main
+- [CI] Update GitHub Actions checkout to v2
+
 ## 2.0.1 - *2021-06-01*
 
 ## 2.0.0 - *2021-05-13*


### PR DESCRIPTION
- [CI] Update ActionsHub actions to point at main
- [CI] Update GitHub Actions checkout to v2

Signed-off-by: Dan Webb <dan.webb@damacus.io>

