### PR TITLE
Fix installing htauth gem and passing resource properties to helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
         os:
           - "debian-11"
           - "debian-12"
-          - "centos-stream-8"
           - "centos-stream-9"
           - "ubuntu-2004"
           - "ubuntu-2204"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This file is used to list changes made in each version of the htpasswd cookbook.
 
+## Unreleased
+
 ## 2.0.17 - *2025-09-04*
 
 - Fix installing `htauth` gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the htpasswd cookbook.
 
 ## Unreleased
 
+- Fix installing `htauth` gem
+- Fix passing resource properties to helpers
+
 ## 2.0.17 - *2025-09-04*
 
 ## 2.0.16 - *2024-12-05*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the htpasswd cookbook.
 
 - Fix installing `htauth` gem
 - Fix passing resource properties to helpers
+- Remove CentOS Stream 8 from CI
 
 ## 2.0.17 - *2025-09-04*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of the htpasswd cookbook.
 
-## Unreleased
+## 2.0.17 - *2025-09-04*
 
 - Fix installing `htauth` gem
 - Fix passing resource properties to helpers

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -52,10 +52,24 @@ module Htpasswd
         nil
       end
 
+      # Use the same method as sous-chefs/postgresql
+      # https://github.com/sous-chefs/postgresql/blob/0b0da2cd955ab550f8e0408779b926dda908dec1/libraries/_utils.rb#L51
+      #
+      # Check if a given gem is installed and available for require
+      #
+      # @return [true, false] Gem installed result
+      #
+      def gem_installed?(gem_name)
+        !Gem::Specification.find_by_name(gem_name).nil?
+      rescue Gem::LoadError
+        false
+      end
+
       def require_htauth
-        require 'htauth'
-      rescue LoadError
-        Chef::Log.error("Missing gem 'htauth'. Use the default htpasswd recipe to install it first.")
+        # https://github.com/sous-chefs/postgresql/blob/0b0da2cd955ab550f8e0408779b926dda908dec1/libraries/sql/_connection.rb#L131-L133
+        Chef::Log.error("Missing gem 'htauth'. Use the default htpasswd recipe to install it first. These were all the found gems: #{Gem::Specification.all_names()}") unless gem_installed?('htauth')
+
+        require 'htauth' unless defined?(::HTAuth)
       end
     end
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,10 +18,14 @@
 # limitations under the License.
 #
 
-build_essential 'htpasswd' do
-  compile_time true
+declare_resource(:build_essential, 'htpasswd') do
+  compile_time(true)
 end
 
-chef_gem 'htauth' do
+# Use declare_resource to ensure these happen at the very start,
+# similar to how sous-chefs/postgresql does it.
+# https://github.com/sous-chefs/postgresql/blob/0b0da2cd955ab550f8e0408779b926dda908dec1/libraries/sql/_connection.rb#L109
+
+declare_resource(:chef_gem, 'htauth') do
   compile_time true
-end
+end unless gem_installed?('htauth')

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,12 @@ declare_resource(:build_essential, 'htpasswd') do
   compile_time true
 end
 
+declare_resource(:link, '/bin/install') do
+  to '/usr/bin/install'
+  compile_time true
+  not_if { ::File.exist? '/bin/install' }
+end
+
 # Use declare_resource to ensure these happen at the very start,
 # similar to how sous-chefs/postgresql does it.
 # https://github.com/sous-chefs/postgresql/blob/0b0da2cd955ab550f8e0408779b926dda908dec1/libraries/sql/_connection.rb#L109

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 #
 
 declare_resource(:build_essential, 'htpasswd') do
-  compile_time(true)
+  compile_time true
 end
 
 # Use declare_resource to ensure these happen at the very start,

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -15,12 +15,16 @@ property :mode, String, default: '0640'
 action :add do
   unless htpasswd_user_set?(@new_resource)
     if ::File.exist?(new_resource.file)
-      converge_by("Add user #{@new_resource.user} in #{@new_resource.name}") do
-        htpasswd_add(@new_resource)
+      ruby_block "Add user #{@new_resource.user} in #{@new_resource.name}" do
+        block do
+          htpasswd_add(@new_resource)
+        end
       end
     else
-      converge_by("Create user #{@new_resource.user} in #{@new_resource.name}") do
-        htpasswd_create(@new_resource)
+      ruby_block "Create user #{@new_resource.user} in #{@new_resource.name}" do
+        block do
+          htpasswd_create(@new_resource)
+        end
       end
     end
   end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -13,17 +13,17 @@ property :type, String,
 property :mode, String, default: '0640'
 
 action :add do
-  unless htpasswd_user_set?(@new_resource)
+  unless htpasswd_user_set?(new_resource)
     if ::File.exist?(new_resource.file)
-      ruby_block "Add user #{@new_resource.user} in #{@new_resource.name}" do
+      ruby_block "Add user #{new_resource.user} in #{new_resource.name}" do
         block do
-          htpasswd_add(@new_resource)
+          htpasswd_add(new_resource)
         end
       end
     else
-      ruby_block "Create user #{@new_resource.user} in #{@new_resource.name}" do
+      ruby_block "Create user #{new_resource.user} in #{new_resource.name}" do
         block do
-          htpasswd_create(@new_resource)
+          htpasswd_create(new_resource)
         end
       end
     end
@@ -32,16 +32,16 @@ action :add do
 end
 
 action :overwrite do
-  converge_by("Overwrite file #{@new_resource.name} with user #{@new_resource.user}") do
-    htpasswd_create(@new_resource)
+  converge_by("Overwrite file #{new_resource.name} with user #{new_resource.user}") do
+    htpasswd_create(new_resource)
   end
   fix_perms(new_resource)
 end
 
 action :delete do
-  if htpasswd_user_exists?(@new_resource)
-    converge_by("Delete user #{@new_resource.user} in #{@new_resource.name}") do
-      htpasswd_delete(@new_resource)
+  if htpasswd_user_exists?(new_resource)
+    converge_by("Delete user #{new_resource.user} in #{new_resource.name}") do
+      htpasswd_delete(new_resource)
     end
   end
   fix_perms(new_resource)

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe 'htpasswd::default' do
   platform 'ubuntu'
 
+  before do
+    allow(Gem::Specification).to receive(:find_by_name).and_return(nil)
+  end
+
   it { is_expected.to install_build_essential('htpasswd').with(compile_time: true) }
   it { is_expected.to install_chef_gem('htauth').with(compile_time: true) }
 end


### PR DESCRIPTION
# Description
- Properly install `htauth` gem before it's ever needed, and add a helper to properly check if `htauth` gem is installed
- Properly pass `htpasswd` resource properties into helper methods

## Issues Resolved

None

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
