### PR TITLE
fix: migrate to Policyfile and map Kitchen suites

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'htpasswd'
+
+run_list 'test::default'
+
+cookbook 'htpasswd', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 
@@ -98,7 +96,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -47,15 +47,18 @@ x-verifiers:
 
 suites:
   - name: default
+    named_run_list: default
     run_list: *default_run_list
     verifier: *default_verifier
   - name: delete
+    named_run_list: delete
     provisioner:
       enforce_idempotency: false
       multiple_converge: 2
     run_list: *delete_run_list
     verifier: *delete_verifier
   - name: overwrite
+    named_run_list: overwrite
     provisioner:
       enforce_idempotency: false
       multiple_converge: 2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- replace Berksfile dependency resolution with Policyfile.rb
- switch ChefSpec setup to Policyfile support where applicable
- update Copilot setup/docs away from berks install
- keep Policyfile.lock.json generated locally and ignored

## Verification
- chef install Policyfile.rb
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- chef exec rspec --format documentation equivalent via Workstation embedded RSpec
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-debian-12 --destroy=always